### PR TITLE
updated requirements to require wp-cli-bundle.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,6 @@
   "homepage": "https://github.com/jonbp/wp-cli-sync",
   "minimum-stability": "dev",
   "require": {
-    "wp-cli/wp-cli": "^2.1",
-    "wp-cli/db-command": "^2.0",
-    "wp-cli/extension-command": "^2.0",
-    "wp-cli/maintenance-mode-command": "2.x-dev"
+    "wp-cli/wp-cli-bundle": "*"
   }
 }


### PR DESCRIPTION
When using this package on a Composer based project, this package installs `wp-cli/wp-cli`, and causes issues if you require other packages. I suggest we replace it with `wp-cli/wp-cli-bundle` to avoid issues.